### PR TITLE
Fixes and RNCryptorSettings refactoring

### DIFF
--- a/RNCryptor.xcodeproj/project.pbxproj
+++ b/RNCryptor.xcodeproj/project.pbxproj
@@ -36,7 +36,6 @@
 		FB7564F71512D3C4007B806B /* RNCryptor-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RNCryptor-Prefix.pch"; sourceTree = "<group>"; };
 		FB7565001512D3C4007B806B /* RNCryptorTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RNCryptorTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB7565011512D3C4007B806B /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
-		FB7565031512D3C4007B806B /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		FB75650B1512D3C4007B806B /* RNCryptorTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "RNCryptorTests-Info.plist"; sourceTree = "<group>"; };
 		FB75650D1512D3C4007B806B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		FB75650F1512D3C4007B806B /* RNCryptorTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNCryptorTests.h; sourceTree = "<group>"; };
@@ -74,7 +73,6 @@
 		FB7564E51512D3C4007B806B = {
 			isa = PBXGroup;
 			children = (
-				FB7565221512D9A8007B806B /* Security.framework */,
 				FB7564F51512D3C4007B806B /* RNCryptor */,
 				FB7565091512D3C4007B806B /* RNCryptorTests */,
 				FB7564F21512D3C4007B806B /* Frameworks */,
@@ -94,9 +92,9 @@
 		FB7564F21512D3C4007B806B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				FB7565221512D9A8007B806B /* Security.framework */,
 				FB7564F31512D3C4007B806B /* Foundation.framework */,
 				FB7565011512D3C4007B806B /* SenTestingKit.framework */,
-				FB7565031512D3C4007B806B /* UIKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/RNCryptor/RNOpenSSLCryptor.h
+++ b/RNCryptor/RNOpenSSLCryptor.h
@@ -43,15 +43,26 @@
 @end
 
 static const RNCryptorSettings kRNCryptorOpenSSLSettings = {
-    .algorithm = kCCAlgorithmAES128,
-    .mode = kCCModeCBC,
-    .modeOptions = 0,
-    .keySize = kCCKeySizeAES256,
-    .blockSize = kCCBlockSizeAES128,
-    .IVSize = kCCBlockSizeAES128,
-    .padding = ccPKCS7Padding,
-    .saltSize = 8,
-    .PBKDFRounds = 0,
-    .HMACAlgorithm = 0,
-    .HMACLength= 0,
+    .cryptor.algorithm = kCCAlgorithmAES128,
+    .cryptor.mode = kCCModeCBC,
+    .cryptor.modeOptions = 0,
+    .cryptor.blockSize = kCCBlockSizeAES128,
+    .cryptor.IVSize = kCCBlockSizeAES128,
+    .cryptor.padding = ccPKCS7Padding,
+    
+    .key = {
+        .keySize = kCCKeySizeAES256,
+        .saltSize = 8,
+        .algorithm = kCCKeySizeAES256,
+        .rounds = 0,
+        .prf = kCCPRFHmacAlgSHA1
+    },
+    
+    .hmacKey = {
+        .keySize = 0,
+        .saltSize = 8,
+        .algorithm = 0,
+        .rounds = 0,
+        .prf = kCCPRFHmacAlgSHA1
+    }
 };


### PR DESCRIPTION
- Refactoring of RNCryptorSettings. Split the crypto setting from the key derivation setting. This way you can configure the HMac key derivation, the crypto key derivation and de cryptor independently. The new structure, RNCryptorKeyDerivationSettings, allows to configure the algorithm and the PRF function for the derivation.
- Fix parameter 'algorithm' in the call to CCHmacInit(). There wasn't use the one configured in the settings.
- Fix the '_RNGetData' and '_RNWriteData' for the 'IV' vector, there wasn't use the size value configured in the settings
