### PR TITLE
Cocoapods Podspec

### DIFF
--- a/RNCryptor.podspec
+++ b/RNCryptor.podspec
@@ -21,6 +21,7 @@ LIC
   s.source_files = 'RNCryptor/*.{h,m}'
   s.public_header_files = 'RNCryptor/*.h'
   s.requires_arc = true
+  s.ios.frameworks = 'Security'
 # OS X building is broken in 2.0.
   s.platform = :ios, '5.0'
 # Comment the above and uncomment below to support OS X and iOS.


### PR DESCRIPTION
Added a podspec for use with [Cocoapods](http://cocoapods.org).

How I'm currently using it in a Podfile:

``` ruby
pod 'RNCryptor', :podspec => 'https://raw.github.com/tyrone-sudeium/RNCryptor/master/RNCryptor.podspec'
```

After merging in the pull request, this should work in theory:

``` ruby
pod 'RNCryptor', :git => 'https://github.com/rnapier/RNCryptor.git'
```
