### PR TITLE
Podspec for RNCryptor

### DIFF
--- a/RNCryptor.podspec
+++ b/RNCryptor.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+  s.name = 'RNCryptor'
+  s.version = '2.0'
+  s.summary = 'an easy-to-use, Objective-C interface to the AES functionality of CommonCrypto.'
+  s.homepage = 'http://robnapier.net/blog/aes-commoncrypto-564'
+  s.license  = {
+    :type => 'MIT',
+    :text => 'This code is licensed under the MIT License:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE'
+    }
+  s.author = 'Rob Napier', 'robnapier@gmail.com'
+  s.source = {
+    :git => 'https://github.com/rnapier/RNCryptor.git',
+    :tag => 'RNCryptor-2.0'
+  }
+  s.platform = :ios, '5.0'
+  s.source_files = 'RNCryptor/'
+  s.public_header_files = 'RNCryptor/'
+  s.frameworks = 'UIKit', 'QuartzCore', 'Security'
+  s.requires_arc = true
+end


### PR DESCRIPTION
Here is a cocoapods podspec for RNCryptor

Passed `pod spec lint` and works from my fork of RNCryptor.

It uses the 2.0 tag
