### PR TITLE
Asynchronous decryption fix

### DIFF
--- a/RNCryptor/RNCryptor.m
+++ b/RNCryptor/RNCryptor.m
@@ -83,7 +83,7 @@ const uint8_t kRNCryptorFileVersion = 1;
   dispatch_release(sem);
   dispatch_release(queue);
 #endif
-    
+
   if (returnedError) {
     if (anError) {
       *anError = returnedError;
@@ -132,12 +132,13 @@ const uint8_t kRNCryptorFileVersion = 1;
   NSParameterAssert(handler);
   self = [super init];
   if (self) {
-    _responseQueue = dispatch_get_current_queue();
-    
+      NSString *responseQueueName = [@"net.robnapier.response." stringByAppendingString:NSStringFromClass([self class])];
+      _responseQueue = dispatch_queue_create([responseQueueName UTF8String], NULL);
+
 #if !OS_OBJECT_USE_OBJC
     dispatch_retain(_responseQueue);
 #endif
-      
+
     NSString *queueName = [@"net.robnapier." stringByAppendingString:NSStringFromClass([self class])];
     _queue = dispatch_queue_create([queueName UTF8String], DISPATCH_QUEUE_SERIAL);
     __outData = [NSMutableData data];


### PR DESCRIPTION
RNCryptor uses dispatch_get_current_queue() in initWithHandler: as the responseQueue. However, due to the recent deprecation of dispatch_get_current_queue() in iOS6 this leads to a situation where the handler is never called. This commit changes the initWithHandler to create a new queue that is then used as the response queue which allows asynchronous decryption to work correctly.

In addition to the change it includes a unit test to verify that it works correctly.

This commit fixes #43

Signed-off-by: Calman Steynberg calman@steynberg.ca
