### PR TITLE
decrypt.php initial implementation.

### DIFF
--- a/php/crypt-common.inc
+++ b/php/crypt-common.inc
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Based on pbkdf2() from https://defuse.ca/php-pbkdf2.htm. Made signature-compatible with hash_pbkdf2() in PHP5.5
+ *
+ * PBKDF2 key derivation function as defined by RSA's PKCS #5: https://www.ietf.org/rfc/rfc2898.txt
+ * $algorithm - The hash algorithm to use. Recommended: SHA256
+ * $password - The password.
+ * $salt - A salt that is unique to the password.
+ * $count - Iteration count. Higher is better, but slower. Recommended: At least 1000.
+ * $key_length - The length of the derived key in bytes.
+ * $raw_output - If true, the key is returned in raw binary format. Hex encoded otherwise.
+ * Returns: A $key_length-byte key derived from the password and salt.
+ *
+ * Test vectors can be found here: https://www.ietf.org/rfc/rfc6070.txt
+ *
+ * This implementation of PBKDF2 was originally created by https://defuse.ca
+ * With improvements by http://www.variations-of-shadow.com
+ */
+function hash_pbkdf2($algorithm, $password, $salt, $count, $key_length = 0, $raw_output = false)
+{
+  $algorithm = strtolower($algorithm);
+  if(!in_array($algorithm, hash_algos(), true))
+    die('PBKDF2 ERROR: Invalid hash algorithm.');
+  if($count <= 0 || $key_length <= 0)
+    die('PBKDF2 ERROR: Invalid parameters.');
+
+  $hash_length = strlen(hash($algorithm, "", true));
+  $block_count = ceil($key_length / $hash_length);
+
+  $output = "";
+  for($i = 1; $i <= $block_count; $i++) {
+        // $i encoded as 4 bytes, big endian.
+    $last = $salt . pack("N", $i);
+        // first iteration
+    $last = $xorsum = hash_hmac($algorithm, $last, $password, true);
+        // perform the other $count - 1 iterations
+    for ($j = 1; $j < $count; $j++) {
+      $xorsum ^= ($last = hash_hmac($algorithm, $last, $password, true));
+    }
+    $output .= $xorsum;
+  }
+
+  if($raw_output)
+    return substr($output, 0, $key_length);
+  else
+    return bin2hex(substr($output, 0, $key_length));
+}

--- a/php/decrypt.php
+++ b/php/decrypt.php
@@ -1,6 +1,7 @@
 <?php
 
 //
+//
 //  AES128-apis.php
 //
 //  RNCryptor PHP BackEnd Script
@@ -11,6 +12,8 @@
 //
 //
 //
+
+require_once("crypt-common.inc");
 
 define('IV_SIZE', 24);
 define('SALT_SIZE', 12);
@@ -113,36 +116,36 @@ function decrypt_data($b64_data) {
                                                                                                                                                                                                                           
 
 /*
-	// Corresponding iOS encrypt codes example.
-	// Use the CPCryptController from https://github.com/iosptl/ios6ptl/blob/master/ch15/CryptPic/CryptPic/RNCryptManager.m
-	if (! [[CPCryptController sharedController] encryptData:srcData password:kRNCryptorPasswd error:&error] ) {
-		NSLog(@"Could not encrypt data: %@", error);
-	}
-	
-	// Do Base64 encoding for AES128 encrypted data
-	NSString *saltBase64 = [[CPCryptController sharedController].salt base64EncodedString];
-	NSString *HMACSaltBase64 = [[CPCryptController sharedController].HMACSalt base64EncodedString];
-	NSString *ivBase64 = [[CPCryptController sharedController].iv base64EncodedString];
-	NSString *encryptedDataBase64 = [[CPCryptController sharedController].encryptedData base64EncodedString];
-	NSString *HMACBase64 = [[CPCryptController sharedController].HMAC base64EncodedString];
-	
-	// Build the final format
-	NSString *encryptedDataBase64Final = [NSString stringWithFormat:@"%@%@%@%@%@",saltBase64, HMACSaltBase64, ivBase64, encryptedDataBase64, HMACBase64];
-	DebugLog(@"encryptedDataBase64Final: %@",encryptedDataBase64Final );
-	
-	//If no error we send the post, voila!
-	if (!error) {
-		
-		NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
-		
-		// Post enctypted
-		[params setObject:encryptedDataBase64Final forKey:@"json_encrypted_base64"];
-		
-		// Do Post!
-		[[RKClient sharedClient] post:postResourcePath params:params delegate:self];
-		
-	}
-*/
+ *	// Corresponding iOS encrypt codes example.
+ *	// Use the CPCryptController from https://github.com/iosptl/ios6ptl/blob/master/ch15/CryptPic/CryptPic/RNCryptManager.m
+ *	if (! [[CPCryptController sharedController] encryptData:srcData password:kRNCryptorPasswd error:&error] ) {
+ *		NSLog(@"Could not encrypt data: %@", error);
+ *	}
+ *	
+ *	// Do Base64 encoding for AES128 encrypted data
+ *	NSString *saltBase64 = [[CPCryptController sharedController].salt base64EncodedString];
+ *	NSString *HMACSaltBase64 = [[CPCryptController sharedController].HMACSalt base64EncodedString];
+ *	NSString *ivBase64 = [[CPCryptController sharedController].iv base64EncodedString];
+ *	NSString *encryptedDataBase64 = [[CPCryptController sharedController].encryptedData base64EncodedString];
+ *	NSString *HMACBase64 = [[CPCryptController sharedController].HMAC base64EncodedString];
+ *	
+ *	// Build the final format
+ *	NSString *encryptedDataBase64Final = [NSString stringWithFormat:@"%@%@%@%@%@",saltBase64, HMACSaltBase64, ivBase64, encryptedDataBase64, HMACBase64];
+ *	DebugLog(@"encryptedDataBase64Final: %@",encryptedDataBase64Final );
+ *	
+ *	//If no error we send the post, voila!
+ *	if (!error) {
+ *		
+ *		NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
+ *		
+ *		// Post enctypted
+ *		[params setObject:encryptedDataBase64Final forKey:@"json_encrypted_base64"];
+ *		
+ *		// Do Post!
+ *		[[RKClient sharedClient] post:postResourcePath params:params delegate:self];
+ *		
+ *	}
+ */ 
 
 function CPCryptController_decrypt_data($data) {
   global $gPassword;
@@ -217,52 +220,4 @@ function CPCryptController_decrypt_data($data) {
   return false;
 }
 
-
-/*
- * Based on pbkdf2() from https://defuse.ca/php-pbkdf2.htm. Made signature-compatible with hash_pbkdf2() in PHP5.5
- *
- * PBKDF2 key derivation function as defined by RSA's PKCS #5: https://www.ietf.org/rfc/rfc2898.txt
- * $algorithm - The hash algorithm to use. Recommended: SHA256
- * $password - The password.
- * $salt - A salt that is unique to the password.
- * $count - Iteration count. Higher is better, but slower. Recommended: At least 1000.
- * $key_length - The length of the derived key in bytes.
- * $raw_output - If true, the key is returned in raw binary format. Hex encoded otherwise.
- * Returns: A $key_length-byte key derived from the password and salt.
- *
- * Test vectors can be found here: https://www.ietf.org/rfc/rfc6070.txt
- *
- * This implementation of PBKDF2 was originally created by https://defuse.ca
- * With improvements by http://www.variations-of-shadow.com
- */
-function hash_pbkdf2($algorithm, $password, $salt, $count, $key_length = 0, $raw_output = false)
-{
-  $algorithm = strtolower($algorithm);
-  if(!in_array($algorithm, hash_algos(), true))
-    die('PBKDF2 ERROR: Invalid hash algorithm.');
-  if($count <= 0 || $key_length <= 0)
-    die('PBKDF2 ERROR: Invalid parameters.');
-
-  $hash_length = strlen(hash($algorithm, "", true));
-  $block_count = ceil($key_length / $hash_length);
-
-  $output = "";
-  for($i = 1; $i <= $block_count; $i++) {
-        // $i encoded as 4 bytes, big endian.
-    $last = $salt . pack("N", $i);
-        // first iteration
-    $last = $xorsum = hash_hmac($algorithm, $last, $password, true);
-        // perform the other $count - 1 iterations
-    for ($j = 1; $j < $count; $j++) {
-      $xorsum ^= ($last = hash_hmac($algorithm, $last, $password, true));
-    }
-    $output .= $xorsum;
-  }
-
-  if($raw_output)
-    return substr($output, 0, $key_length);
-  else
-    return bin2hex(substr($output, 0, $key_length));
-}
-
-
+?>

--- a/php/encrypt.php
+++ b/php/encrypt.php
@@ -1,5 +1,7 @@
 <?php
 
+  require_once("crypt-common.inc");
+
   /* Your data goes here */
   $password = "myPassword";
   $plaintext = "here is my test vector. It's not too long, but more than a block and needs padding";
@@ -57,52 +59,5 @@
   $envelope = $message . $hmac;
 
   echo base64_encode($envelope), "\n";
-
-/*
- * Based on pbkdf2() from https://defuse.ca/php-pbkdf2.htm. Made signature-compatible with hash_pbkdf2() in PHP5.5
- *
- * PBKDF2 key derivation function as defined by RSA's PKCS #5: https://www.ietf.org/rfc/rfc2898.txt
- * $algorithm - The hash algorithm to use. Recommended: SHA256
- * $password - The password.
- * $salt - A salt that is unique to the password.
- * $count - Iteration count. Higher is better, but slower. Recommended: At least 1000.
- * $key_length - The length of the derived key in bytes.
- * $raw_output - If true, the key is returned in raw binary format. Hex encoded otherwise.
- * Returns: A $key_length-byte key derived from the password and salt.
- *
- * Test vectors can be found here: https://www.ietf.org/rfc/rfc6070.txt
- *
- * This implementation of PBKDF2 was originally created by https://defuse.ca
- * With improvements by http://www.variations-of-shadow.com
- */
-function hash_pbkdf2($algorithm, $password, $salt, $count, $key_length = 0, $raw_output = false)
-{
-  $algorithm = strtolower($algorithm);
-  if(!in_array($algorithm, hash_algos(), true))
-    die('PBKDF2 ERROR: Invalid hash algorithm.');
-  if($count <= 0 || $key_length <= 0)
-    die('PBKDF2 ERROR: Invalid parameters.');
-
-  $hash_length = strlen(hash($algorithm, "", true));
-  $block_count = ceil($key_length / $hash_length);
-
-  $output = "";
-  for($i = 1; $i <= $block_count; $i++) {
-        // $i encoded as 4 bytes, big endian.
-    $last = $salt . pack("N", $i);
-        // first iteration
-    $last = $xorsum = hash_hmac($algorithm, $last, $password, true);
-        // perform the other $count - 1 iterations
-    for ($j = 1; $j < $count; $j++) {
-      $xorsum ^= ($last = hash_hmac($algorithm, $last, $password, true));
-    }
-    $output .= $xorsum;
-  }
-
-  if($raw_output)
-    return substr($output, 0, $key_length);
-  else
-    return bin2hex(substr($output, 0, $key_length));
-}
 
 ?>


### PR DESCRIPTION
Hi Rob,

I've finally made the first version of the decrypt.php through a lot of research and tests.

I am using the CPCryptController for encrypting in iOS side.
(https://github.com/iosptl/ios6ptl/blob/master/ch15/CryptPic/CryptPic/RNCryptManager.m)

Below is the corresponding encryption codes in iOS to use the decrypt.php.

``` objective-c
// Corresponding iOS encrypt codes example.
// Use the CPCryptController from https://github.com/iosptl/ios6ptl/blob/master/ch15/CryptPic/CryptPic/RNCryptManager.m
if (! [[CPCryptController sharedController] encryptData:srcData password:kRNCryptorPasswd error:&error] ) {
    NSLog(@"Could not encrypt data: %@", error);
}

// Do Base64 encoding for AES128 encrypted data
NSString *saltBase64 = [[CPCryptController sharedController].salt base64EncodedString];
NSString *HMACSaltBase64 = [[CPCryptController sharedController].HMACSalt base64EncodedString];
NSString *ivBase64 = [[CPCryptController sharedController].iv base64EncodedString];
NSString *encryptedDataBase64 = [[CPCryptController sharedController].encryptedData base64EncodedString];
NSString *HMACBase64 = [[CPCryptController sharedController].HMAC base64EncodedString];

// Build the final format
NSString *encryptedDataBase64Final = [NSString stringWithFormat:@"%@%@%@%@%@",saltBase64, HMACSaltBase64, ivBase64, encryptedDataBase64, HMACBase64];
DebugLog(@"encryptedDataBase64Final: %@",encryptedDataBase64Final );

//If no error we send the post, voila!
if (!error) {   
    NSMutableDictionary *params = [[NSMutableDictionary alloc] init];

    // Post enctypted
    [params setObject:encryptedDataBase64Final forKey:@"JASON_Enc_Base64"];

    // Do Post!
    [[RKClient sharedClient] post:postResourcePath params:params delegate:self];        
}
```

I hope this help.
Thanks.
