### PR TITLE
Minor changes to command-line tool

### DIFF
--- a/rncrypt/main.m
+++ b/rncrypt/main.m
@@ -31,7 +31,7 @@ NSData *GetDataForHex(NSString *hex)
 }
 
 void usage() {
-  printf("Not like that\n");
+  printf("Encode: rncrypt -p <password> Some text to encode\nDecode: rncrypt -d -p <password> Some text to decode\n");
   exit(2);
 }
 
@@ -50,7 +50,7 @@ int main(int argc, char * const argv[])
 {
   @autoreleasepool {
 
-    int decrypt_flag;
+    int decrypt_flag = 0;
     NSString *password = nil;
     NSString *message = nil;
 


### PR DESCRIPTION
1. Set default value of decrypt_flag to 0 so that encoding works (uninitalized was a positive number interfering with the decode value - it was basically always trying to invoke the decode function)
2. Added more detailed usage
