### PR TITLE
Fix issues identified by Infer

### DIFF
--- a/RNCryptor/RNEncryptor.m
+++ b/RNCryptor/RNEncryptor.m
@@ -153,7 +153,7 @@
                                IV:(NSData *)anIV
                    encryptionSalt:(NSData *)anEncryptionSalt
                          HMACSalt:(NSData *)anHMACSalt
-                          handler:(RNCryptorHandler)aHandler;
+                          handler:(RNCryptorHandler)aHandler
 {
   NSParameterAssert(aPassword.length > 0);  // We'll go forward, but this is undefined behavior for RNCryptor
   NSParameterAssert(anIV);
@@ -199,7 +199,7 @@
       NSData *header = [self header];
       [self.outData setData:header];
       if (self.hasHMAC) {
-        CCHmacUpdate(&_HMACContext, [header bytes], [header length]);
+        CCHmacUpdate(&self->_HMACContext, [header bytes], [header length]);
       }
       self.haveWrittenHeader = YES;
     }
@@ -210,7 +210,7 @@
       [self cleanupAndNotifyWithError:error];
     }
     if (self.hasHMAC) {
-      CCHmacUpdate(&_HMACContext, encryptedData.bytes, encryptedData.length);
+      CCHmacUpdate(&self->_HMACContext, encryptedData.bytes, encryptedData.length);
     }
 
     [self.outData appendData:encryptedData];
@@ -233,9 +233,9 @@
     NSData *encryptedData = [self.engine finishWithError:&error];
     [self.outData appendData:encryptedData];
     if (self.hasHMAC) {
-      CCHmacUpdate(&_HMACContext, encryptedData.bytes, encryptedData.length);
+      CCHmacUpdate(&self->_HMACContext, encryptedData.bytes, encryptedData.length);
       NSMutableData *HMACData = [NSMutableData dataWithLength:self.HMACLength];
-      CCHmacFinal(&_HMACContext, [HMACData mutableBytes]);
+      CCHmacFinal(&self->_HMACContext, [HMACData mutableBytes]);
       [self.outData appendData:HMACData];
     }
     [self cleanupAndNotifyWithError:error];


### PR DESCRIPTION
Fixing issues identified by [Infer](https://github.com/facebook/infer) and add explicit self to blocks that implicitly retained it.

```
RNCryptor/RNDecryptor.m:69: error: NULL_DEREFERENCE
   pointer otherBytes last assigned on line 61 could be null and is dereferenced at line 69, column 39

RNCryptor/RNDecryptor.m:201: error: NULL_DEREFERENCE
   pointer data last assigned on line 200 could be null and is dereferenced by call to decryptData: at line 201, column 7

RNCryptor/RNDecryptor.m:212: warning: PARAMETER_NOT_NULL_CHECKED
   Parameter preamble is not checked for null, there could be a null pointer dereference: pointer bytes last assigned on line 208 could be null and is dereferenced at line 212, column 7
```