### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ header.
 `RNCryptor suports asynchronous use, specifically designed to work with
 `NSURLConnection. This is also useful for cases where the encrypted or decrypted
 `data will not comfortably fit in memory. If the data will comfortably fit in
-`memory, asynchronous operation is best acheived using dispatch_async().
+`memory, asynchronous operation is best achieved using dispatch_async().
 
 To operate in asynchronous mode, you create an `RNEncryptor` or `RNDecryptor`,
 providing it a handler. This handler will be called as data is encrypted or


### PR DESCRIPTION
@RNCryptor, I've corrected a typographical error in the documentation of the [RNCryptor](https://github.com/RNCryptor/RNCryptor) project. Specifically, I've changed acheive to achieve. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.