### PR TITLE
Specify the pod's swift_version

### DIFF
--- a/RNCryptor.podspec
+++ b/RNCryptor.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
 	s.description = 'Implements a secure encryption format based on AES, PBKDF2, and HMAC.'
 	s.homepage = 'https://github.com/rnapier/RNCryptor'
 	s.source_files = 'Sources/RNCryptor/RNCryptor.swift', 'Sources/Cryptor/include/RNCryptor.h'
+	s.swift_version = '4.1'
 	s.ios.deployment_target = '8.0'
 	s.osx.deployment_target = '10.9'
 	s.watchos.deployment_target = '2.0'


### PR DESCRIPTION
Otherwise, the used `swift_version` depends on swift version of the app's target.

see https://github.com/CocoaPods/CocoaPods/issues/7327

I've used the version you have noted in `.swift-version`. Nevertheless, I recommend updating to swift 4.2, as Xcode 10.1 doesn't know swift 4.1, but 3.0, 4.0 and 4.2.