### PR TITLE
import modular CommonCrypto header if available

### DIFF
--- a/Sources/RNCryptor/RNCryptor.swift
+++ b/Sources/RNCryptor/RNCryptor.swift
@@ -26,9 +26,8 @@
 
 import Foundation
 #if canImport(CommonCrypto)
-importCommonCrypto
-#endif
-#if SWIFT_PACKAGE
+import CommonCrypto
+#elseif SWIFT_PACKAGE
 import Cryptor
 #endif
 

--- a/Sources/RNCryptor/RNCryptor.swift
+++ b/Sources/RNCryptor/RNCryptor.swift
@@ -603,7 +603,7 @@ internal final class Engine {
         }
 
         // Note that since iOS 6, CCryptor will never return padding errors or other decode errors.
-        // I'm not aware of any non-catestrophic (MemoryAllocation) situation in which this
+        // I'm not aware of any non-catastrophic (MemoryAllocation) situation in which this
         // can fail. Using assert() just in case, but we'll ignore errors in Release.
         // https://devforums.apple.com/message/920802#920802
         assert(result == CCCryptorStatus(kCCSuccess), "RNCRYPTOR BUG. PLEASE REPORT. (\(result)")
@@ -751,12 +751,12 @@ internal final class OverflowingBuffer {
 
 /** Compare two Datas in time proportional to the untrusted data
 
-Equatable-based comparisons genreally stop comparing at the first difference.
+Equatable-based comparisons generally stop comparing at the first difference.
 This can be used by attackers, in some situations,
 to determine a secret value by considering the time required to compare the values.
 
 We enumerate over the untrusted values so that the time is proportaional to the attacker's data,
-which provides the attack no informatoin about the length of the secret.
+which provides the attack no information about the length of the secret.
 */
 private func isEqualInConsistentTime(trusted: Data, untrusted: Data) -> Bool {
     // The point of this routine is XOR the bytes of each data and accumulate the results with OR.

--- a/Sources/RNCryptor/RNCryptor.swift
+++ b/Sources/RNCryptor/RNCryptor.swift
@@ -25,6 +25,9 @@
 //
 
 import Foundation
+#if canImport(CommonCrypto)
+importCommonCrypto
+#endif
 #if SWIFT_PACKAGE
 import Cryptor
 #endif


### PR DESCRIPTION
With Xcode 10 and swift 4.2 the CommonCrypto library seems to have gotten its long awaited modular header. So if it is available we do not need the Objective-C Bridging header anymore. It suffices to import the RNCryptor.swift file in a project. It is even possible to paste the content of the main file RNCryptor.swift into a swift playground on the iPad and you can then use all the Encryption/Decryption functionalities in the Playground.

With this change the project compiles normally on MacOS Xcode 10 and Swift 4.2 and all Tests still pass. I could not check linux build - but as the proven solution of importing Cryptor if the CommonCrypto headers are not found is used in the else if branch it should be ok. 

Thank you Rob for this fantastic repository. I am thrilled that I can now use it standalone and even in swift playgrounds for iPad.
